### PR TITLE
Remove all mentions of keyboard shortcuts and the relevant dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,4 @@ dependencies = [
     "bibtexparser>=1.4.3",
     "requests>=2.32.3",
     "streamlit>=1.41.1",
-    "streamlit-shortcuts>=0.1.9",
 ]

--- a/src/pages/dblp.py
+++ b/src/pages/dblp.py
@@ -7,7 +7,6 @@ import json
 import re
 from datetime import datetime
 from typing import Dict, List, Optional
-from streamlit_shortcuts import button, add_keyboard_shortcuts
 import urllib.request
 from bibtexparser.bibdatabase import BibDatabase
 
@@ -175,15 +174,6 @@ def add_todo_note(entry: Dict) -> Dict:
 st.title("BibTeX DBLP Resolver")
 st.write("Upload your BibTeX file and resolve entries with DBLP.")
 
-st.markdown("""
-**Keyboard Shortcuts:**
-- `Enter` or `Y`: Accept match
-- `Esc` or `N`: Decline match
-- `1`-`5`: Select match number (when multiple matches shown)
-
-**Note:** Exact matches are automatically accepted
-""")
-
 uploaded_file = st.file_uploader("Choose a BibTeX file", type=['bib'])
 
 if uploaded_file:
@@ -245,11 +235,11 @@ if uploaded_file:
                     cols = st.columns(min(len(dblp_results) + 1, 6))
                     for i in range(min(len(dblp_results), 5)):
                         with cols[i]:
-                            if button(f"{i + 1}", str(i + 1), lambda i=i: handle_accept(entry, dblp_results[i]), hint=True):
-                                pass
+                            if st.button(f"{i + 1}"):
+                                handle_accept(entry, dblp_results[i])
                     with cols[-1]:
-                        if button("❌", "Escape", lambda: handle_decline(entry), hint=True):
-                            pass
+                        if st.button("❌"):
+                            handle_decline(entry)
             else:
                 st.subheader("No Matches Found")
                 st.text(format_entry_for_display(entry))

--- a/uv.lock
+++ b/uv.lock
@@ -560,18 +560,6 @@ wheels = [
 ]
 
 [[package]]
-name = "streamlit-shortcuts"
-version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "streamlit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/6a/8b39496d9771a88d9660d8bd7b8331064cfab78749a03e6b287a9e7f6e56/streamlit_shortcuts-0.1.9.tar.gz", hash = "sha256:0d19a430f214143371e57c1c8fc021927317db01d204cbda7c380124065466e0", size = 5400 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/48/a76df0487c8ef878800e9abc266e26e66eb280d84d5e0976ef89b66aa19e/streamlit_shortcuts-0.1.9-py3-none-any.whl", hash = "sha256:f0b37c912614a1fd0cd069476946a3354a779a64a332e80bc16f2e769e63bfbb", size = 5261 },
-]
-
-[[package]]
 name = "tenacity"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -598,7 +586,6 @@ dependencies = [
     { name = "bibtexparser" },
     { name = "requests" },
     { name = "streamlit" },
-    { name = "streamlit-shortcuts" },
 ]
 
 [package.metadata]
@@ -607,7 +594,6 @@ requires-dist = [
     { name = "bibtexparser", specifier = ">=1.4.3" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "streamlit", specifier = ">=1.41.1" },
-    { name = "streamlit-shortcuts", specifier = ">=0.1.9" },
 ]
 
 [[package]]
@@ -666,7 +652,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
     { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
     { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
-    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c2574d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
     { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },


### PR DESCRIPTION
Remove all mentions of keyboard shortcuts and the relevant dependencies.

* **Dependency Removal:**
  - Remove `streamlit-shortcuts` dependency from `pyproject.toml`.
  - Remove `streamlit-shortcuts` package entry from `uv.lock`.

* **Code Changes in `src/pages/dblp.py`:**
  - Remove import statement for `streamlit_shortcuts`.
  - Remove `button` and `add_keyboard_shortcuts` functions.
  - Remove keyboard shortcuts section from the Streamlit page content.
  - Replace `button` function calls with `st.button` calls.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Xceron/tools/pull/1?shareId=63e3e4da-c795-4e17-a3c6-4937e72ec474).